### PR TITLE
Add custom scrollbar for mozilla firefox browser

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -21,7 +21,7 @@ a {
 }
 
 ::-webkit-scrollbar {
-  width: 15px;
+  width: 10px;
 }
 
 ::-webkit-scrollbar-track {
@@ -37,4 +37,11 @@ a {
 
 ::-webkit-scrollbar-thumb:hover {
   background: #b58f4a; 
+}
+
+.scroller {
+  height: 100vh;
+  overflow-y: scroll;
+  scrollbar-color: #ffc760 #160101;
+  scrollbar-width: auto;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ import Social from "./component/Contact/Social";
 
 function App() {
   return (
-    <div>
+    <div className="scroller">
       <Header />
       <About />
       <Skills />


### PR DESCRIPTION
Hey @Starboy-Sharma 
Continuing the enhancement for issue #3 and PR #4.
I did some research and seems as per the documentation the custom scrollbar works differently for mozilla and in order to style it using just css we have limited options.
I have added some styling which will make it somewhat similar to the one on chrome. Also have reduced the width of the chrome scrollbar to make it look similar to one on mozilla firefox. 
I have also checked the scrollbar for opera, chrome, edge and brave. It is working fine. I don't own a mac and for windows the latest version of safari is not available. So cannot comment on it but from the documentation it does seem it works on safari as well.
Please look at below screenshots for reference:

Documentation (from https://developer.mozilla.org/en-US/docs/Web/CSS/::-webkit-scrollbar)
![Screenshot_20230225_115351](https://user-images.githubusercontent.com/20976813/221342622-5117ec38-52c7-4ceb-b622-1d2baefbe453.png)

Firefox
![Screenshot_20230225_115607](https://user-images.githubusercontent.com/20976813/221342634-7b629ae0-bb65-4f31-b3db-214b14b0877a.png)

Chrome
![Screenshot_20230225_115623](https://user-images.githubusercontent.com/20976813/221342661-36fe5c8c-cbdc-4aa1-acb7-0b29ab7605f5.png)






